### PR TITLE
Use scapy 2.5.0 for Python 3.10 and higher

### DIFF
--- a/custom_components/tailwind_iq3/manifest.json
+++ b/custom_components/tailwind_iq3/manifest.json
@@ -5,7 +5,10 @@
   "config_flow": true,
   "documentation": "https://github.com/pauln/tailwind-home-assistant",
   "issue_tracker": "https://github.com/pauln/tailwind-home-assistant/issues",
-  "requirements": ["scapy==2.4.5"],
+  "requirements": [
+    "scapy==2.4.5; python_version<'3.10'",
+    "scapy==2.5.0; python_version>='3.10'"
+  ],
   "ssdp": [],
   "zeroconf": [
     {


### PR DESCRIPTION
This breaks on the latest Home Assistant OS because the Python version has been upgraded to 3.10. Scapy has [specific versions per Python version](https://scapy.net/download/).

Resolves #13 