### PR TITLE
Replace async_setup_platforms

### DIFF
--- a/custom_components/tailwind_iq3/__init__.py
+++ b/custom_components/tailwind_iq3/__init__.py
@@ -71,7 +71,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = {TAILWIND_COORDINATOR: coordinator}
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
 
     return True
 


### PR DESCRIPTION
This replaces `async_setup_platforms` with `async_forward_entry_setup`. https://github.com/home-assistant/core/pull/73806 increased the verbosity from DEBUG to WARNING.