### PR TITLE
Add BinarySensor for Tailwind iQ3

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/pylint:2": {}
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git config --global user.email \"${localEnv:GIT_EMAIL}\" && git config --global user.name \"${localEnv:GIT_NAME}\" && pip3 install --user -r requirements.txt",
+	"runArgs": [
+		"--network=host",
+		"--dns-opt='single-request'"
+	],
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+	// Customizations
+	"extensions": [
+		"ms-python.python",
+		"github.vscode-pull-request-github",
+		"ryanluker.vscode-coverage-gutters",
+		"ms-python.vscode-pylance"
+	],
+	"settings": {
+		"terminal.integrated.defaultProfile.linux": "bash",
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+				"icon": "terminal-bash"
+			}
+		},
+		"files.eol": "\n",
+		"editor.tabSize": 4,
+		"python.pythonPath": "/usr/bin/python3",
+		"python.analysis.autoSearchPaths": false,
+		// This makes sure the home assistant types are loaded into the editor
+		"python.analysis.extraPaths": [
+			"/home/vscode/.local/lib/python3.10/site-packages/"
+		],
+		"python.linting.pylintEnabled": true,
+		"python.linting.enabled": true,
+		"python.formatting.provider": "black",
+		"editor.formatOnPaste": false,
+		"editor.formatOnSave": true,
+		"editor.formatOnType": true,
+		"files.trimTrailingWhitespace": true
+	},
+	"appPort": 8123
+}

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignore the home assistant config folder, generated when using a devcontainer
+config/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Home Assistant",
+            "type": "python",
+            "request": "launch",
+            "module": "homeassistant",
+            "justMyCode": false,
+            "args": [
+                "--debug",
+                "-c",
+                "config"
+            ]
+        },
+        {
+            "name": "Home Assistant (skip pip)",
+            "type": "python",
+            "request": "launch",
+            "module": "homeassistant",
+            "justMyCode": false,
+            "args": [
+                "--debug",
+                "-c",
+                "config",
+                "--skip-pip"
+            ]
+        }
+    ]
+}

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,0 +1,20 @@
+# Example configuration.yaml entry
+default_config:
+
+logger:
+  default: info
+  logs:
+    custom_components.tailwind_iq3: debug
+
+# Run with debugpy and wait for debugger to connect
+# debugpy:
+#   start: true
+#   wait: true
+
+# Enable this part if you want to use CodeSpaces
+# http:
+#   use_x_forwarded_for: true
+#   trusted_proxies:
+#     - 127.0.0.1
+#   ip_ban_enabled: true
+#   login_attempts_threshold: 3

--- a/custom_components/tailwind_iq3/__init__.py
+++ b/custom_components/tailwind_iq3/__init__.py
@@ -11,9 +11,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
     DataUpdateCoordinator,
     UpdateFailed,
 )
@@ -24,9 +22,11 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["cover"]
 
 
-async def tailwind_get_status(hass: HomeAssistant, ip_address: str, api_token: str) -> str:
+async def tailwind_get_status(
+    hass: HomeAssistant, ip_address: str, api_token: str
+) -> str:
     websession = async_get_clientsession(hass)
-    headers = {'TOKEN': api_token}
+    headers = {"TOKEN": api_token}
     async with websession.get(f"http://{ip_address}/status", headers=headers) as resp:
         assert resp.status == 200
         return await resp.text()
@@ -36,8 +36,10 @@ async def tailwind_send_command(
     hass: HomeAssistant, ip_address: str, api_token: str, command: str
 ) -> str:
     websession = async_get_clientsession(hass)
-    headers = {'TOKEN': api_token}
-    async with websession.post(f"http://{ip_address}/cmd", data=command, headers=headers) as resp:
+    headers = {"TOKEN": api_token}
+    async with websession.post(
+        f"http://{ip_address}/cmd", data=command, headers=headers
+    ) as resp:
         assert resp.status == 200
         return await resp.text()
 

--- a/custom_components/tailwind_iq3/__init__.py
+++ b/custom_components/tailwind_iq3/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import (
 from .const import DOMAIN, TAILWIND_COORDINATOR, UPDATE_INTERVAL, ATTR_RAW_STATE
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS = ["cover"]
+PLATFORMS = ["binary_sensor", "cover"]
 
 
 async def tailwind_get_status(

--- a/custom_components/tailwind_iq3/__init__.py
+++ b/custom_components/tailwind_iq3/__init__.py
@@ -86,28 +86,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-class TailwindEntity(CoordinatorEntity):
-    """Base class for Tailwind iQ3 Entities."""
-
-    def __init__(self, coordinator: DataUpdateCoordinator, device: DeviceEntry) -> None:
-        super().__init__(coordinator)
-        self._device = device
-        self._attr_unique_id = device.device_id
-
-    @property
-    def name(self):
-        return self._device.name
-
-    @property
-    def device_info(self):
-        device_info = {
-            "identifiers": {(DOMAIN, self._device.device_id)},
-            "name": self._device.name,
-            "manufacturer": "Tailwind",
-            "model": "iQ3",
-        }
-        if self._device.parent_device_id:
-            device_info["via_device"] = (DOMAIN, self._device.parent_device_id)
-        return device_info

--- a/custom_components/tailwind_iq3/binary_sensor.py
+++ b/custom_components/tailwind_iq3/binary_sensor.py
@@ -1,0 +1,53 @@
+"""Binary sensor that indicates if the door is open or closed."""
+import logging
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_GARAGE_DOOR,
+    BinarySensorEntity,
+    BinarySensorDeviceClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import CONF_NUM_DOORS, DOMAIN, TAILWIND_COORDINATOR
+from .entity import TailwindEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+):
+    """Set up cover entities."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][TAILWIND_COORDINATOR]
+    num_doors = config_entry.data.get(CONF_NUM_DOORS, 1)
+
+    async_add_entities(
+        [TailwindBinarySensor(hass, coordinator, device) for device in range(num_doors)]
+    )
+
+
+class TailwindBinarySensor(TailwindEntity, BinarySensorEntity):
+    """Representation of a Tailwind iQ3 cover."""
+
+    _attr_device_class = DEVICE_CLASS_GARAGE_DOOR
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: DataUpdateCoordinator,
+        device: DeviceEntry,
+    ):
+        """Initialize with API object, device id."""
+        super().__init__(coordinator, device)
+        self._hass = hass
+
+    @property
+    def device_class(self) -> BinarySensorDeviceClass:
+        return DEVICE_CLASS_GARAGE_DOOR
+
+    @property
+    def is_on(self) -> bool | None:
+        return self.is_open

--- a/custom_components/tailwind_iq3/cover.py
+++ b/custom_components/tailwind_iq3/cover.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import HomeAssistantError
 
 from . import tailwind_send_command
-from .const import CONF_NUM_DOORS, DOMAIN, TAILWIND_COORDINATOR, ATTR_RAW_STATE
+from .const import CONF_NUM_DOORS, DOMAIN, TAILWIND_COORDINATOR
 from .entity import TailwindEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,40 +42,6 @@ class TailwindCover(TailwindEntity, CoverEntity):
         """Initialize with API object, device id."""
         super().__init__(coordinator, device)
         self._hass = hass
-
-    @property
-    def is_closed(self):
-        if self.coordinator.data is None:
-            return None
-
-        if self.coordinator.data[ATTR_RAW_STATE] == -1:
-            return None
-
-        return not self.is_open
-
-    @property
-    def is_closing(self):
-        """Return if the cover is closing or not."""
-        return False
-
-    @property
-    def is_open(self):
-        if self.coordinator.data is None:
-            return None
-
-        if self.coordinator.data[ATTR_RAW_STATE] == -1:
-            return None
-
-        raw_state = self.coordinator.data[ATTR_RAW_STATE]
-        bit_pos = 1 << self._device
-
-        """Return true if cover is open, else False."""
-        return raw_state & bit_pos
-
-    @property
-    def is_opening(self):
-        """Return if the cover is opening or not."""
-        return False
 
     async def async_close_cover(self, **kwargs):
         """Issue close command to cover."""

--- a/custom_components/tailwind_iq3/entity.py
+++ b/custom_components/tailwind_iq3/entity.py
@@ -13,20 +13,26 @@ class TailwindEntity(CoordinatorEntity):
     def __init__(self, coordinator: DataUpdateCoordinator, device: DeviceEntry) -> None:
         super().__init__(coordinator)
         self._device = device
-        self._attr_unique_id = device.device_id
-
-    @property
-    def name(self):
-        return self._device.name
 
     @property
     def device_info(self):
-        device_info = {
-            "identifiers": {(DOMAIN, self._device.device_id)},
-            "name": self._device.name,
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
             "manufacturer": "Tailwind",
             "model": "iQ3",
         }
-        if self._device.parent_device_id:
-            device_info["via_device"] = (DOMAIN, self._device.parent_device_id)
-        return device_info
+
+    @property
+    def name(self):
+        # Default name to match Tailwind app's default names.
+        door_letter = ["A", "B", "C"][self._device]
+        return f"Garage {door_letter}"
+
+    @property
+    def unique_id(self):
+        # Set unique ID based on device unique ID and door number.
+        coordinator_id = self.coordinator.config_entry.unique_id.replace(
+            "tailwind-", ""
+        )
+        return f"{coordinator_id}_door_{self._device}"

--- a/custom_components/tailwind_iq3/entity.py
+++ b/custom_components/tailwind_iq3/entity.py
@@ -39,7 +39,7 @@ class TailwindEntity(CoordinatorEntity):
 
     @property
     def is_closed(self) -> bool | None:
-        """Return if the cover is closed or not."""
+        """Return true if cover is closed, else False."""
         return not self.is_open
 
     @property

--- a/custom_components/tailwind_iq3/entity.py
+++ b/custom_components/tailwind_iq3/entity.py
@@ -1,0 +1,32 @@
+from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN
+
+
+class TailwindEntity(CoordinatorEntity):
+    """Base class for Tailwind iQ3 Entities."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, device: DeviceEntry) -> None:
+        super().__init__(coordinator)
+        self._device = device
+        self._attr_unique_id = device.device_id
+
+    @property
+    def name(self):
+        return self._device.name
+
+    @property
+    def device_info(self):
+        device_info = {
+            "identifiers": {(DOMAIN, self._device.device_id)},
+            "name": self._device.name,
+            "manufacturer": "Tailwind",
+            "model": "iQ3",
+        }
+        if self._device.parent_device_id:
+            device_info["via_device"] = (DOMAIN, self._device.parent_device_id)
+        return device_info

--- a/custom_components/tailwind_iq3/entity.py
+++ b/custom_components/tailwind_iq3/entity.py
@@ -4,7 +4,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DOMAIN
+from .const import ATTR_RAW_STATE, DOMAIN
 
 
 class TailwindEntity(CoordinatorEntity):
@@ -36,3 +36,29 @@ class TailwindEntity(CoordinatorEntity):
             "tailwind-", ""
         )
         return f"{coordinator_id}_door_{self._device}"
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return if the cover is closed or not."""
+        return not self.is_open
+
+    @property
+    def is_closing(self) -> bool | None:
+        """Return if the cover is closing or not."""
+        return False
+
+    @property
+    def is_open(self) -> bool | None:
+        """Return true if cover is open, else False."""
+        raw_state = self.coordinator.data.get(ATTR_RAW_STATE, -1)
+        if raw_state == -1:
+            return None
+
+        bit_pos = 1 << self._device
+
+        return raw_state & bit_pos
+
+    @property
+    def is_opening(self) -> bool | None:
+        """Return if the cover is opening or not."""
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+homeassistant


### PR DESCRIPTION
Adds a BinarySensor for Tailwind iQ3 which can be used for things like Alarmo.

This also adds the ability to launch the integration into a devcontainer with a fresh HASS install, which makes testing easier.

Resolves #2 