### PR TITLE
Update cover.py

### DIFF
--- a/custom_components/tailwind_iq3/cover.py
+++ b/custom_components/tailwind_iq3/cover.py
@@ -2,9 +2,9 @@
 import logging
 
 from homeassistant.components.cover import (
-    DEVICE_CLASS_GARAGE,
-    SUPPORT_CLOSE,
-    SUPPORT_OPEN,
+    CoverDeviceClass.GARAGE,
+    CoverEntityFeature.CLOSE,
+    CoverEntityFeature.OPEN,
     CoverEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -44,8 +44,8 @@ async def async_setup_entry(
 class TailwindCover(TailwindEntity, CoverEntity):
     """Representation of a Tailwind iQ3 cover."""
 
-    _attr_supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
-    _attr_device_class = DEVICE_CLASS_GARAGE
+    _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    _attr_device_class = CoverDeviceClass.GARAGE
     _controller: TailwindController
 
     def __init__(


### PR DESCRIPTION
Updated deprecated constants as follows:
DEVICE_CLASS_GARAGE was used from tailwind_iq3, this is a deprecated constant which will be removed in HA Core 2025.1. Use CoverDeviceClass.GARAGE instead

SUPPORT_CLOSE was used from tailwind_iq3, this is a deprecated constant which will be removed in HA Core 2025.1. Use CoverEntityFeature.CLOSE instead

SUPPORT_OPEN was used from tailwind_iq3, this is a deprecated constant which will be removed in HA Core 2025.1. Use CoverEntityFeature.OPEN instead